### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Guava is a super lightweight and high performance web framework for Python writt
 
 Keep in mind, this project is not to revent the wheel.
 
-If you don't like the features Guava supplied, you can use the underlying structures like **router**, **session**, **request**, **response**, **builtin web server** to construct your own web framework with the benifits of high performance which guava gives you.
+If you don't like the features Guava supplied, you can use the underlying structures like **router**, **session**, **request**, **response**, **builtin web server** to construct your own web framework with the benefits of high performance which guava gives you.
 
 You can check out the detailed explaination of guava in my blog. [Link](http://code-trick.com)
 

--- a/src/guava_request.c
+++ b/src/guava_request.c
@@ -367,7 +367,7 @@ int guava_request_on_message_complete(http_parser *parser) {
       if (router->router->type != GUAVA_ROUTER_CUSTOM) {
         /*
          * Cause we already try to get the best matched router
-         * But we still need to pass the custome router in case use defined some speciall routes
+         * But we still need to pass the custom router in case use defined some special routes
          */
         continue;
       }


### PR DESCRIPTION
There are small typos in:
- README.md
- src/guava_request.c

Fixes:
- Should read `special` rather than `speciall`.
- Should read `custom` rather than `custome`.
- Should read `benefits` rather than `benifits`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md